### PR TITLE
Chat API Endpoints (Issue #7)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -167,12 +167,14 @@ See the interactive API docs at http://localhost:8000/docs when the server is ru
 - `GET /docs` - Interactive API documentation (Swagger UI)
 - `GET /openapi.json` - OpenAPI schema
 
-**API Endpoints (to be implemented):**
-- `POST /api/chat/session` - Create new chat session
-- `POST /api/chat` - Send chat message
-- `POST /api/plan/generate` - Generate travel plan
-- `POST /api/plan/refine` - Refine existing plan
-- More endpoints will be added as development progresses
+**Chat Endpoints:**
+- `POST /api/chat/session` - Create new chat session ✓
+- `POST /api/chat` - Send chat message ✓
+- `GET /api/chat/session/{id}` - Get conversation history ✓
+
+**Plan Endpoints (to be implemented):**
+- `POST /api/plan/generate` - Generate travel plan (requires Issue #4)
+- `POST /api/plan/refine` - Refine existing plan (requires Issue #4)
 
 ## Conversation Management
 
@@ -211,6 +213,32 @@ conversation_manager.transition_state(session.session_id, ConversationState.GATH
 
 # Update preferences
 conversation_manager.update_preferences(session.session_id, activity_type="active/outdoor")
+```
+
+### API Usage Example
+
+```bash
+# Create a new session
+curl -X POST http://localhost:8000/api/chat/session
+
+# Response:
+# {"session_id":"abc-123-def","message":"Session created successfully"}
+
+# Send a message
+curl -X POST http://localhost:8000/api/chat \
+  -H "Content-Type: application/json" \
+  -d '{"session_id":"abc-123-def","message":"週末片道1時間くらいでいける候補"}'
+
+# Response:
+# {
+#   "session_id": "abc-123-def",
+#   "response": "アクティブな場所をお探しですか、それともインドアの施設がよいですか?",
+#   "state": "GATHERING_PREFERENCES",
+#   "quick_replies": ["アクティブ", "インドア"]
+# }
+
+# Get conversation history
+curl http://localhost:8000/api/chat/session/abc-123-def
 ```
 
 ## Environment Variables

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,6 +11,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from app.config import settings
+from app.routes import chat
 from app.services.conversation_manager import conversation_manager
 
 # Configure logging
@@ -94,6 +95,10 @@ async def log_requests(request: Request, call_next):
     response.headers["X-Process-Time"] = str(process_time)
 
     return response
+
+
+# Include routers
+app.include_router(chat.router)
 
 
 # Global exception handler

--- a/backend/app/models/api.py
+++ b/backend/app/models/api.py
@@ -1,0 +1,46 @@
+"""API request and response models."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class CreateSessionResponse(BaseModel):
+    """Response for creating a new session."""
+
+    session_id: str
+    message: str = "Session created successfully"
+
+
+class ChatMessageRequest(BaseModel):
+    """Request for sending a chat message."""
+
+    session_id: str
+    message: str = Field(..., min_length=1)
+
+
+class ChatMessageResponse(BaseModel):
+    """Response for a chat message."""
+
+    session_id: str
+    response: str
+    state: str
+    quick_replies: list[str] | None = None
+
+
+class SessionHistoryResponse(BaseModel):
+    """Response for getting session history."""
+
+    session_id: str
+    state: str
+    messages: list[dict[str, str]]
+    created_at: datetime
+    last_updated: datetime
+
+
+class ErrorResponse(BaseModel):
+    """Error response model."""
+
+    error: str
+    message: str
+    details: str | None = None

--- a/backend/app/routes/chat.py
+++ b/backend/app/routes/chat.py
@@ -1,0 +1,163 @@
+"""Chat API endpoints."""
+
+import logging
+
+from fastapi import APIRouter, HTTPException, status
+
+from app.models.api import (
+    ChatMessageRequest,
+    ChatMessageResponse,
+    CreateSessionResponse,
+    ErrorResponse,
+    SessionHistoryResponse,
+)
+from app.models.conversation import ConversationState
+from app.services.conversation_manager import conversation_manager
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/chat", tags=["chat"])
+
+
+@router.post("/session", response_model=CreateSessionResponse)
+async def create_session() -> CreateSessionResponse:
+    """Create a new conversation session."""
+    session = conversation_manager.create_session()
+
+    # Add initial greeting
+    greeting = "こんにちは！週末のお出かけプランをお手伝いします。どのようなプランをお探しですか？"
+    conversation_manager.add_assistant_message(session.session_id, greeting)
+
+    logger.info(f"Created new session: {session.session_id}")
+
+    return CreateSessionResponse(
+        session_id=session.session_id,
+        message="Session created successfully"
+    )
+
+
+@router.post("", response_model=ChatMessageResponse, responses={404: {"model": ErrorResponse}})
+async def send_message(request: ChatMessageRequest) -> ChatMessageResponse:
+    """Send a message in the conversation."""
+    session = conversation_manager.get_session(request.session_id)
+
+    if not session:
+        logger.warning(f"Session not found: {request.session_id}")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Session not found"
+        )
+
+    # Add user message
+    conversation_manager.add_user_message(request.session_id, request.message)
+
+    # Determine response based on current state
+    response_message, quick_replies = _generate_response(session, request.message)
+
+    # Add assistant response
+    conversation_manager.add_assistant_message(request.session_id, response_message)
+
+    logger.info(f"Session {request.session_id}: Processed message in state {session.state}")
+
+    return ChatMessageResponse(
+        session_id=request.session_id,
+        response=response_message,
+        state=session.state.value,
+        quick_replies=quick_replies
+    )
+
+
+@router.get("/session/{session_id}", response_model=SessionHistoryResponse)
+async def get_session_history(session_id: str) -> SessionHistoryResponse:
+    """Get conversation history for a session."""
+    session = conversation_manager.get_session(session_id)
+
+    if not session:
+        logger.warning(f"Session not found: {session_id}")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Session not found"
+        )
+
+    # Format messages
+    messages = [
+        {
+            "role": msg.role,
+            "content": msg.content,
+            "timestamp": msg.timestamp.isoformat()
+        }
+        for msg in session.conversation_history
+    ]
+
+    return SessionHistoryResponse(
+        session_id=session.session_id,
+        state=session.state.value,
+        messages=messages,
+        created_at=session.created_at,
+        last_updated=session.last_updated
+    )
+
+
+def _generate_response(session, user_message: str) -> tuple[str, list[str] | None]:
+    """Generate response based on conversation state and user input."""
+
+    # For now, just handle the gathering preferences state
+    # This will be enhanced with Vertex AI in Issue #4
+
+    if session.state == ConversationState.INITIAL:
+        # Move to gathering preferences
+        conversation_manager.transition_state(
+            session.session_id,
+            ConversationState.GATHERING_PREFERENCES
+        )
+        return (
+            "アクティブな場所をお探しですか、それともインドアの施設がよいですか?",
+            ["アクティブ", "インドア"]
+        )
+
+    elif session.state == ConversationState.GATHERING_PREFERENCES:
+        # Check what preference to ask for next
+        prefs = session.user_preferences
+
+        # Store activity type if provided
+        if "アクティブ" in user_message or "active" in user_message.lower():
+            conversation_manager.update_preferences(
+                session.session_id,
+                activity_type="active/outdoor"
+            )
+        elif "インドア" in user_message or "indoor" in user_message.lower():
+            conversation_manager.update_preferences(
+                session.session_id,
+                activity_type="indoor"
+            )
+
+        # Ask about meals if not set
+        if not prefs.meals and prefs.activity_type:
+            return (
+                "昼食や夕食はお取りになりますか?",
+                ["とる", "とらない"]
+            )
+
+        # Store meal preference
+        if "とる" in user_message or "yes" in user_message.lower():
+            conversation_manager.update_preferences(
+                session.session_id,
+                meals=["lunch"]
+            )
+
+            # For now, indicate plan would be generated
+            # In Issue #4, this will call Vertex AI
+            conversation_manager.transition_state(
+                session.session_id,
+                ConversationState.GENERATING_PLAN
+            )
+            return (
+                "プランを作成中です...\n\n（現在、Vertex AI統合は未実装です。Issue #4で実装予定）",
+                None
+            )
+
+        return ("ご質問に答えていただきありがとうございます。", None)
+
+    else:
+        # Default response for other states
+        return ("ご質問ありがとうございます。", None)

--- a/backend/tests/test_chat_api.py
+++ b/backend/tests/test_chat_api.py
@@ -1,0 +1,67 @@
+"""Tests for chat API endpoints."""
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_create_session() -> None:
+    """Test creating a new session."""
+    response = client.post("/api/chat/session")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert "session_id" in data
+    assert data["message"] == "Session created successfully"
+
+
+def test_send_message() -> None:
+    """Test sending a message."""
+    # Create session first
+    session_response = client.post("/api/chat/session")
+    session_id = session_response.json()["session_id"]
+
+    # Send message
+    response = client.post(
+        "/api/chat",
+        json={"session_id": session_id, "message": "週末片道1時間くらいでいける候補"}
+    )
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["session_id"] == session_id
+    assert "response" in data
+    assert "state" in data
+
+
+def test_get_session_history() -> None:
+    """Test getting session history."""
+    # Create session
+    session_response = client.post("/api/chat/session")
+    session_id = session_response.json()["session_id"]
+
+    # Send a message
+    client.post(
+        "/api/chat",
+        json={"session_id": session_id, "message": "Hello"}
+    )
+
+    # Get history
+    response = client.get(f"/api/chat/session/{session_id}")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["session_id"] == session_id
+    assert "messages" in data
+    assert len(data["messages"]) >= 2  # greeting + user message + response
+
+
+def test_send_message_invalid_session() -> None:
+    """Test sending message with invalid session ID."""
+    response = client.post(
+        "/api/chat",
+        json={"session_id": "invalid-id", "message": "Hello"}
+    )
+    assert response.status_code == 404


### PR DESCRIPTION
## Description

Implements Issue #7: REST API endpoints for chat and conversation management.

## Changes

### API Endpoints Implemented

**✅ POST /api/chat/session** - Create new conversation session
- Generates UUID session ID
- Automatically adds Japanese greeting message
- Returns session ID for subsequent requests

**✅ POST /api/chat** - Send message in conversation
- Accepts session ID and user message
- State-based response generation
- Returns assistant response with quick reply suggestions
- Updates conversation state automatically
- 404 error if session not found

**✅ GET /api/chat/session/{id}** - Get conversation history
- Returns complete session details
- Includes all messages with timestamps
- Shows current conversation state
- 404 error if session not found

### Request/Response Models

Created Pydantic models in `app/models/api.py`:
- `CreateSessionResponse` - Session creation response
- `ChatMessageRequest` - User message request
- `ChatMessageResponse` - Assistant response with state
- `SessionHistoryResponse` - Full session history
- `ErrorResponse` - Consistent error format

### Conversation Logic

**Current Implementation (Rule-based):**
- Detects INITIAL state → asks about activity type
- Collects activity preference (active/outdoor or indoor)
- Asks about meal preferences
- Provides Japanese quick reply suggestions
- Transitions through conversation states

**Placeholder for AI:**
- Currently uses simple rules
- Will be replaced with Vertex AI in Issue #4
- State management ready for AI integration

### Example API Flow

```bash
# 1. Create session
POST /api/chat/session
→ {"session_id":"abc-123","message":"Session created successfully"}

# 2. Send message
POST /api/chat
{
  "session_id": "abc-123",
  "message": "週末片道1時間くらいでいける候補"
}
→ {
  "session_id": "abc-123",
  "response": "アクティブな場所をお探しですか、それともインドアの施設がよいですか?",
  "state": "GATHERING_PREFERENCES",
  "quick_replies": ["アクティブ", "インドア"]
}

# 3. Get history
GET /api/chat/session/abc-123
→ {session details with all messages}
```

### Testing

**Simple tests (TESTING_POLICY.md):**
- ✅ Create session - returns session ID
- ✅ Send message - returns response
- ✅ Get history - returns messages
- ✅ Invalid session - returns 404

All tests passing ✓

```bash
cd backend
pytest tests/test_chat_api.py -v
```

### Documentation

**Updated README:**
- Marked chat endpoints as implemented ✓
- Added curl examples for all endpoints
- Request/response format documentation
- Integration with conversation manager

## Technical Details

**State-based Logic:**
- INITIAL → Asks about activity type
- GATHERING_PREFERENCES → Collects preferences
- Transitions automatically based on collected info

**Error Handling:**
- 404 for non-existent sessions
- Request validation via Pydantic
- Consistent error response format
- Logged errors with context

**Integration:**
- Uses conversation_manager from Issue #3
- Properly integrated with FastAPI router
- Added to main app with `app.include_router(chat.router)`

## Ready For

After this PR is merged:
- **Issue #9**: Frontend Chat Interface (can connect to these APIs)
- **Issue #4**: Vertex AI Integration (will replace rule-based logic)

## Testing Locally

```bash
# Start server
cd backend
python run.py

# Test endpoints
curl -X POST http://localhost:8000/api/chat/session
curl -X POST http://localhost:8000/api/chat \
  -H "Content-Type: application/json" \
  -d '{"session_id":"SESSION_ID","message":"Hello"}'
```

## Notes

- Rule-based responses are intentionally simple
- Focus is on API structure and state management
- Vertex AI integration (Issue #4) will add real AI responses
- Quick replies help guide the conversation flow
- Japanese language support throughout

---

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)