### PR TITLE
Fix backend setup for uv package manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,5 @@ Thumbs.db
 # Temporary files
 *.tmp
 *.temp
+
+service_account.json

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -23,12 +23,14 @@ dev = [
     "mypy>=1.7.0",
     "ruff>=0.1.6",
     "black>=23.11.0",
-    "types-googlemaps>=4.10.0",
 ]
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["app"]
 
 [tool.mypy]
 python_version = "3.11"


### PR DESCRIPTION
## Summary
- Fix pyproject.toml configuration to work with uv package manager
- Enable successful installation of backend dependencies

## Changes
1. **Remove non-existent dependency**: Removed `types-googlemaps>=4.10.0` from dev dependencies (package doesn't exist in PyPI)
2. **Add hatchling config**: Added `[tool.hatch.build.targets.wheel]` to specify that the `app/` directory contains the package code
3. **Update .gitignore**: Added explicit `service_account.json` entry for clarity

## Testing
- ✅ `uv pip install -e ".[dev]"` completes successfully  
- ✅ Backend server starts and runs
- ✅ Health endpoint responds correctly
- ✅ All dependencies installed (70 packages)

## Related Issues
Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)