### PR TITLE
Add place drawer with detailed information

### DIFF
--- a/frontend/src/components/ChatContainer.tsx
+++ b/frontend/src/components/ChatContainer.tsx
@@ -5,6 +5,7 @@ import QuickReplies from './QuickReplies';
 import MapDisplay from './MapDisplay';
 import PlanSummary from './PlanSummary';
 import EnrichedPlaceCard from './EnrichedPlaceCard';
+import PlaceDrawer from './PlaceDrawer';
 import type { TravelPlan } from '../types/plan';
 import { mockPlan } from '../data/mockPlan';
 import { useSession } from '../hooks/useSession';
@@ -42,6 +43,9 @@ export default function ChatContainer() {
   });
   const [mapMarkers, setMapMarkers] = useState<Location[]>([]);
   const [mapRoutes, setMapRoutes] = useState<Location[][]>([]);
+
+  // Drawer state
+  const [selectedPlaceIndex, setSelectedPlaceIndex] = useState<number | null>(null);
 
   // Auto-scroll to bottom when new messages arrive
   const scrollToBottom = () => {
@@ -118,9 +122,28 @@ export default function ChatContainer() {
     setQuickReplies([]);
   };
 
-  const handlePlaceClick = (activityId: string) => {
-    console.log('Place clicked:', activityId);
-    // TODO: Highlight place on map or show details
+  const handlePlaceClick = (placeId: string) => {
+    // Find the index of the place in enrichedPlaces
+    const index = enrichedPlaces.findIndex((p) => p.place_id === placeId);
+    if (index !== -1) {
+      setSelectedPlaceIndex(index);
+    }
+  };
+
+  const handleCloseDrawer = () => {
+    setSelectedPlaceIndex(null);
+  };
+
+  const handlePreviousPlace = () => {
+    if (selectedPlaceIndex !== null && selectedPlaceIndex > 0) {
+      setSelectedPlaceIndex(selectedPlaceIndex - 1);
+    }
+  };
+
+  const handleNextPlace = () => {
+    if (selectedPlaceIndex !== null && selectedPlaceIndex < enrichedPlaces.length - 1) {
+      setSelectedPlaceIndex(selectedPlaceIndex + 1);
+    }
   };
 
   const handleSeeMoreOptions = () => {
@@ -258,17 +281,14 @@ export default function ChatContainer() {
               {enrichedPlaces && enrichedPlaces.length > 0 && (
                 <div className="mb-6">
                   <h3 className="text-lg font-semibold text-gray-800 mb-4">
-                    おすすめスポット
+                    おすすめスポット ({enrichedPlaces.length}件)
                   </h3>
-                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                  <div className="space-y-3">
                     {enrichedPlaces.map((place) => (
                       <EnrichedPlaceCard
                         key={place.place_id}
                         place={place}
-                        onClick={(placeId) => {
-                          console.log('Place clicked:', placeId);
-                          // TODO: Highlight place on map or show details
-                        }}
+                        onClick={handlePlaceClick}
                       />
                     ))}
                   </div>
@@ -298,6 +318,19 @@ export default function ChatContainer() {
           <MapDisplay markers={mapMarkers} routes={mapRoutes} />
         </div>
       </div>
+
+      {/* Place Drawer */}
+      {selectedPlaceIndex !== null && enrichedPlaces[selectedPlaceIndex] && (
+        <PlaceDrawer
+          place={enrichedPlaces[selectedPlaceIndex]}
+          isOpen={selectedPlaceIndex !== null}
+          onClose={handleCloseDrawer}
+          onPrevious={handlePreviousPlace}
+          onNext={handleNextPlace}
+          hasPrevious={selectedPlaceIndex > 0}
+          hasNext={selectedPlaceIndex < enrichedPlaces.length - 1}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/EnrichedPlaceCard.tsx
+++ b/frontend/src/components/EnrichedPlaceCard.tsx
@@ -6,7 +6,7 @@ interface EnrichedPlaceCardProps {
 }
 
 /**
- * EnrichedPlaceCard - Displays enriched place information with photo
+ * EnrichedPlaceCard - Compact list view for places
  */
 export default function EnrichedPlaceCard({ place, onClick }: EnrichedPlaceCardProps) {
   const handleClick = () => {
@@ -15,127 +15,123 @@ export default function EnrichedPlaceCard({ place, onClick }: EnrichedPlaceCardP
     }
   };
 
-  const handleViewOnGoogleMaps = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    window.open(
-      `https://www.google.com/maps/place/?q=place_id:${place.place_id}`,
-      '_blank'
-    );
-  };
-
   return (
     <div
-      className="bg-white rounded-lg shadow-md overflow-hidden border border-gray-200 hover:shadow-lg transition-shadow cursor-pointer"
+      className="bg-white rounded-lg shadow-sm border border-gray-200 hover:shadow-md hover:border-blue-300 transition-all cursor-pointer overflow-hidden"
       onClick={handleClick}
     >
-      {/* Place Photo */}
-      {place.photo_url && (
-        <div className="w-full h-48 overflow-hidden bg-gray-100">
-          <img
-            src={place.photo_url}
-            alt={place.name}
-            className="w-full h-full object-cover"
-            onError={(e) => {
-              e.currentTarget.style.display = 'none';
-            }}
-          />
-        </div>
-      )}
-
-      {/* Place Information */}
-      <div className="p-4">
-        {/* Name */}
-        <h3 className="text-lg font-bold text-gray-900 mb-2">{place.name}</h3>
-
-        {/* Rating */}
-        {place.rating && (
-          <div className="flex items-center gap-2 mb-2">
-            <div className="flex items-center">
-              <svg
-                className="w-5 h-5 text-yellow-400"
-                fill="currentColor"
-                viewBox="0 0 20 20"
-              >
-                <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
-              </svg>
-              <span className="ml-1 text-sm font-semibold text-gray-700">
-                {place.rating.toFixed(1)}
-              </span>
+      <div className="flex gap-4 p-4">
+        {/* Thumbnail Photo */}
+        <div className="flex-shrink-0">
+          {place.photo_url ? (
+            <div className="w-20 h-20 rounded-lg overflow-hidden bg-gray-100">
+              <img
+                src={place.photo_url}
+                alt={place.name}
+                className="w-full h-full object-cover"
+                onError={(e) => {
+                  e.currentTarget.style.display = 'none';
+                }}
+              />
             </div>
-            {place.user_ratings_total && (
-              <span className="text-sm text-gray-500">
-                ({place.user_ratings_total.toLocaleString()}件)
-              </span>
-            )}
-          </div>
-        )}
-
-        {/* Address */}
-        {place.formatted_address && (
-          <p className="text-sm text-gray-600 mb-2 line-clamp-2">
-            <svg
-              className="w-4 h-4 inline-block mr-1 text-gray-400"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
-              />
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
-              />
-            </svg>
-            {place.formatted_address}
-          </p>
-        )}
-
-        {/* Action Buttons */}
-        <div className="flex gap-2 mt-4">
-          {place.website && (
-            <a
-              href={place.website}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={(e) => e.stopPropagation()}
-              className="flex-1 px-3 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors text-center"
-            >
-              ウェブサイト
-            </a>
+          ) : (
+            <div className="w-20 h-20 rounded-lg bg-gray-100 flex items-center justify-center">
+              <svg
+                className="w-10 h-10 text-gray-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                />
+              </svg>
+            </div>
           )}
-          <button
-            onClick={handleViewOnGoogleMaps}
-            className="flex-1 px-3 py-2 bg-white border border-gray-300 text-gray-800 text-sm font-medium rounded-lg hover:bg-gray-50 transition-colors"
-          >
-            Google Maps
-          </button>
         </div>
 
-        {/* Phone */}
-        {place.phone && (
-          <p className="text-sm text-gray-600 mt-3">
-            <svg
-              className="w-4 h-4 inline-block mr-1 text-gray-400"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"
-              />
-            </svg>
-            {place.phone}
-          </p>
-        )}
+        {/* Place Info */}
+        <div className="flex-1 min-w-0">
+          {/* Name */}
+          <h3 className="text-base font-bold text-gray-900 truncate mb-1">
+            {place.name}
+          </h3>
+
+          {/* Rating */}
+          {place.rating && (
+            <div className="flex items-center gap-2 mb-1">
+              <div className="flex items-center">
+                <svg
+                  className="w-4 h-4 text-yellow-400"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                >
+                  <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+                </svg>
+                <span className="ml-1 text-sm font-semibold text-gray-700">
+                  {place.rating.toFixed(1)}
+                </span>
+              </div>
+              {place.user_ratings_total && (
+                <span className="text-xs text-gray-500">
+                  ({place.user_ratings_total.toLocaleString()}件)
+                </span>
+              )}
+            </div>
+          )}
+
+          {/* Address */}
+          {place.formatted_address && (
+            <p className="text-sm text-gray-600 truncate">
+              <svg
+                className="w-3 h-3 inline-block mr-1 text-gray-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                />
+              </svg>
+              {place.formatted_address}
+            </p>
+          )}
+        </div>
+
+        {/* Arrow Icon */}
+        <div className="flex-shrink-0 flex items-center">
+          <svg
+            className="w-6 h-6 text-gray-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M9 5l7 7-7 7"
+            />
+          </svg>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/PlaceDrawer.tsx
+++ b/frontend/src/components/PlaceDrawer.tsx
@@ -1,0 +1,359 @@
+import { useEffect } from 'react';
+import type { EnrichedPlace } from '../services/api';
+
+interface PlaceDrawerProps {
+  place: EnrichedPlace;
+  isOpen: boolean;
+  onClose: () => void;
+  onPrevious?: () => void;
+  onNext?: () => void;
+  hasPrevious?: boolean;
+  hasNext?: boolean;
+}
+
+/**
+ * PlaceDrawer - Detailed place information drawer
+ * Shows on right side (desktop) or bottom (mobile)
+ */
+export default function PlaceDrawer({
+  place,
+  isOpen,
+  onClose,
+  onPrevious,
+  onNext,
+  hasPrevious = false,
+  hasNext = false,
+}: PlaceDrawerProps) {
+  // Close on ESC key
+  useEffect(() => {
+    const handleEsc = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      window.addEventListener('keydown', handleEsc);
+    }
+
+    return () => {
+      window.removeEventListener('keydown', handleEsc);
+    };
+  }, [isOpen, onClose]);
+
+  // Prevent body scroll when drawer is open
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  // Simple markdown to HTML conversion
+  const renderMarkdown = (text?: string) => {
+    if (!text) return null;
+
+    return (
+      <div className="prose prose-sm max-w-none">
+        {text.split('\n').map((line, index) => {
+          // Headers
+          if (line.startsWith('###')) {
+            return (
+              <h3 key={index} className="text-lg font-bold text-gray-900 mt-4 mb-2">
+                {line.replace(/^###\s*/, '')}
+              </h3>
+            );
+          }
+          if (line.startsWith('##')) {
+            return (
+              <h2 key={index} className="text-xl font-bold text-gray-900 mt-4 mb-2">
+                {line.replace(/^##\s*/, '')}
+              </h2>
+            );
+          }
+
+          // Bullet points
+          if (line.trim().startsWith('-')) {
+            const content = line.replace(/^-\s*/, '');
+            // Bold text
+            const withBold = content.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+            return (
+              <li
+                key={index}
+                className="ml-4 text-gray-700"
+                dangerouslySetInnerHTML={{ __html: withBold }}
+              />
+            );
+          }
+
+          // Empty lines
+          if (line.trim() === '') {
+            return <br key={index} />;
+          }
+
+          // Regular text with bold
+          const withBold = line.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+          return (
+            <p
+              key={index}
+              className="text-gray-700 my-1"
+              dangerouslySetInnerHTML={{ __html: withBold }}
+            />
+          );
+        })}
+      </div>
+    );
+  };
+
+  return (
+    <>
+      {/* Background Overlay */}
+      <div
+        className="fixed inset-0 bg-black bg-opacity-50 z-40 transition-opacity"
+        onClick={onClose}
+      />
+
+      {/* Drawer */}
+      <div
+        className={`
+          fixed z-50 bg-white shadow-2xl overflow-hidden
+          md:top-0 md:right-0 md:h-full md:w-2/5
+          max-md:bottom-0 max-md:left-0 max-md:right-0 max-md:h-4/5 max-md:rounded-t-2xl
+          transform transition-transform duration-300 ease-in-out
+          ${isOpen ? 'translate-x-0 translate-y-0' : 'md:translate-x-full max-md:translate-y-full'}
+        `}
+      >
+        {/* Header with Close Button */}
+        <div className="sticky top-0 bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between z-10">
+          <h2 className="text-xl font-bold text-gray-900 truncate pr-4">
+            {place.name}
+          </h2>
+          <button
+            onClick={onClose}
+            className="flex-shrink-0 p-2 hover:bg-gray-100 rounded-full transition-colors"
+            aria-label="Close"
+          >
+            <svg
+              className="w-6 h-6 text-gray-600"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="overflow-y-auto h-full pb-32">
+          {/* Photo */}
+          {place.photo_url && (
+            <div className="w-full h-64 bg-gray-100">
+              <img
+                src={place.photo_url}
+                alt={place.name}
+                className="w-full h-full object-cover"
+                onError={(e) => {
+                  e.currentTarget.style.display = 'none';
+                }}
+              />
+            </div>
+          )}
+
+          <div className="px-6 py-6 space-y-6">
+            {/* Rating */}
+            {place.rating && (
+              <div className="flex items-center gap-3">
+                <div className="flex items-center">
+                  <svg
+                    className="w-6 h-6 text-yellow-400"
+                    fill="currentColor"
+                    viewBox="0 0 20 20"
+                  >
+                    <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+                  </svg>
+                  <span className="ml-2 text-lg font-semibold text-gray-800">
+                    {place.rating.toFixed(1)}
+                  </span>
+                </div>
+                {place.user_ratings_total && (
+                  <span className="text-sm text-gray-500">
+                    ({place.user_ratings_total.toLocaleString()}件の評価)
+                  </span>
+                )}
+              </div>
+            )}
+
+            {/* Address */}
+            {place.formatted_address && (
+              <div>
+                <h3 className="text-sm font-semibold text-gray-600 mb-2">住所</h3>
+                <p className="text-gray-800 flex items-start gap-2">
+                  <svg
+                    className="w-5 h-5 text-gray-400 flex-shrink-0 mt-0.5"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                    />
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                    />
+                  </svg>
+                  {place.formatted_address}
+                </p>
+              </div>
+            )}
+
+            {/* Phone */}
+            {place.phone && (
+              <div>
+                <h3 className="text-sm font-semibold text-gray-600 mb-2">電話番号</h3>
+                <a
+                  href={`tel:${place.phone}`}
+                  className="text-blue-600 hover:text-blue-700 flex items-center gap-2"
+                >
+                  <svg
+                    className="w-5 h-5"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"
+                    />
+                  </svg>
+                  {place.phone}
+                </a>
+              </div>
+            )}
+
+            {/* Website & Google Maps Buttons */}
+            <div className="flex gap-3">
+              {place.website && (
+                <a
+                  href={place.website}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex-1 px-4 py-3 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors text-center"
+                >
+                  ウェブサイト
+                </a>
+              )}
+              <a
+                href={`https://www.google.com/maps/place/?q=place_id:${place.place_id}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex-1 px-4 py-3 bg-white border border-gray-300 text-gray-800 text-sm font-medium rounded-lg hover:bg-gray-50 transition-colors text-center"
+              >
+                Google Maps
+              </a>
+            </div>
+
+            {/* LLM Description */}
+            {place.llm_description && (
+              <div className="border-t border-gray-200 pt-6">
+                <h3 className="text-lg font-semibold text-gray-900 mb-3">詳細情報</h3>
+                {renderMarkdown(place.llm_description)}
+              </div>
+            )}
+
+            {/* Reviews */}
+            {place.reviews && place.reviews.length > 0 && (
+              <div className="border-t border-gray-200 pt-6">
+                <h3 className="text-lg font-semibold text-gray-900 mb-4">
+                  口コミ ({place.reviews.length}件)
+                </h3>
+                <div className="space-y-4">
+                  {place.reviews.map((review, index) => (
+                    <div
+                      key={index}
+                      className="p-4 bg-gray-50 rounded-lg border border-gray-200"
+                    >
+                      <div className="flex items-center justify-between mb-2">
+                        <div className="flex items-center gap-2">
+                          <span className="font-semibold text-gray-800 text-sm">
+                            {review.author_name}
+                          </span>
+                          <div className="flex items-center">
+                            {[...Array(5)].map((_, i) => (
+                              <svg
+                                key={i}
+                                className={`w-4 h-4 ${
+                                  i < review.rating ? 'text-yellow-400' : 'text-gray-300'
+                                }`}
+                                fill="currentColor"
+                                viewBox="0 0 20 20"
+                              >
+                                <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+                              </svg>
+                            ))}
+                          </div>
+                        </div>
+                        <span className="text-xs text-gray-500">
+                          {review.relative_time_description}
+                        </span>
+                      </div>
+                      <p className="text-sm text-gray-700 leading-relaxed">{review.text}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Footer with Navigation Buttons */}
+        {(hasPrevious || hasNext) && (
+          <div className="absolute bottom-0 left-0 right-0 bg-white border-t border-gray-200 px-6 py-4 flex items-center justify-between">
+            <button
+              onClick={onPrevious}
+              disabled={!hasPrevious}
+              className={`px-4 py-2 rounded-lg font-medium transition-colors ${
+                hasPrevious
+                  ? 'bg-blue-600 text-white hover:bg-blue-700'
+                  : 'bg-gray-200 text-gray-400 cursor-not-allowed'
+              }`}
+            >
+              ← 前のスポット
+            </button>
+            <button
+              onClick={onNext}
+              disabled={!hasNext}
+              className={`px-4 py-2 rounded-lg font-medium transition-colors ${
+                hasNext
+                  ? 'bg-blue-600 text-white hover:bg-blue-700'
+                  : 'bg-gray-200 text-gray-400 cursor-not-allowed'
+              }`}
+            >
+              次のスポット →
+            </button>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -42,9 +42,17 @@ export function useChat(sessionId: string | null) {
       try {
         const response = await chatAPI.sendMessage(sessionId, messageText);
 
+        // Determine what message to show
+        let displayText = response.response;
+
+        // If we have enriched places, show a simple message instead of the full plan description
+        if (response.enriched_places && response.enriched_places.length > 0) {
+          displayText = `${response.enriched_places.length}件のおすすめスポットを見つけました。詳細は下のリストから各スポットをクリックしてご確認ください。`;
+        }
+
         // Add assistant response
         const assistantMessage: Message = {
-          text: response.response,
+          text: displayText,
           isUser: false,
           timestamp: new Date().toISOString(),
         };

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -12,6 +12,14 @@ export interface SessionResponse {
   message: string;
 }
 
+export interface PlaceReview {
+  author_name: string;
+  rating: number;
+  text: string;
+  time: number;
+  relative_time_description: string;
+}
+
 export interface EnrichedPlace {
   id: string;
   place_id: string;
@@ -28,6 +36,8 @@ export interface EnrichedPlace {
   website?: string;
   phone?: string;
   types?: string[];
+  reviews?: PlaceReview[];
+  llm_description?: string;
 }
 
 export interface ChatResponse {


### PR DESCRIPTION
## Summary
- Implement drawer UI for detailed place information
- Extract and display LLM descriptions from plan text
- Simplify place cards to compact list view
- Hide verbose plan descriptions in chat

## Changes

### Backend
- **chat.py**: Extract LLM descriptions from markdown sections
  - `_extract_place_descriptions()`: Parse `### 1. [施設名]` sections
  - Add `llm_description` field to enriched places
  - Full markdown section stored (header + bullets)

### Frontend
- **PlaceDrawer.tsx** (new): Responsive drawer component
  - Desktop: slides from right (40% width)
  - Mobile: slides from bottom (80% height)
  - Displays: photo, rating, address, phone, website, LLM description, reviews
  - Navigation: prev/next buttons for browsing places
  - Close: X button + ESC key
  - Background overlay with click-to-close

- **EnrichedPlaceCard.tsx**: Simplified to compact list view
  - Horizontal layout: thumbnail (80px) + basic info
  - Shows: name, rating, address
  - Removed accordion/reviews (moved to drawer)
  - Entire card clickable

- **ChatContainer.tsx**: Drawer integration
  - State management for selected place index
  - Handlers for open/close/prev/next
  - Changed grid to single column list (`space-y-3`)

- **useChat.ts**: Simplified chat messages
  - When enriched_places exist, replace verbose plan description
  - Shows: "X件のおすすめスポットを見つけました。詳細は下のリストから各スポットをクリックしてご確認ください。"

- **api.ts**: Added `llm_description?: string` to `EnrichedPlace` interface

## UI/UX Improvements
- ✅ Clean chat interface (no long markdown text)
- ✅ Easy-to-scan list view for places
- ✅ Detailed information available on-demand
- ✅ Smooth navigation between places
- ✅ Responsive design (desktop + mobile)
- ✅ Keyboard support (ESC to close)

## Test Plan
- [x] Backend: LLM descriptions extracted correctly
- [x] Frontend: Drawer opens on card click
- [x] Frontend: Prev/next navigation works
- [x] Frontend: ESC and X button close drawer
- [x] Frontend: Mobile responsive layout
- [x] Frontend: Chat shows simplified message
- [x] No build errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)