### PR TITLE
Implement age selection with dropdown and quick replies (Issue #38)

### DIFF
--- a/backend/app/routes/chat.py
+++ b/backend/app/routes/chat.py
@@ -347,9 +347,9 @@ def _generate_response(session, user_message: str) -> tuple[str, list[str] | Non
 
         # Store child age if provided
         if "歳" in user_message or "才" in user_message:
-            # Extract age from message
+            # Extract age from message (supports both "3歳" and "0-3歳" formats)
             import re
-            age_match = re.search(r'(\d+)[歳才]', user_message)
+            age_match = re.search(r'(\d+(?:-\d+)?)[歳才]', user_message)
             if age_match:
                 conversation_manager.update_preferences(
                     session.session_id,
@@ -469,8 +469,8 @@ def _generate_response(session, user_message: str) -> tuple[str, list[str] | Non
 
         if prefs.activity_type and prefs.meals is not None and not prefs.child_age:
             return (
-                "お子様の年齢を教えてください。（例: 3歳、5歳）",
-                None,
+                "お子様の年齢を教えてください。",
+                ["0-2歳", "3-5歳", "6-8歳", "9-12歳", "その他"],
                 None
             )
 

--- a/frontend/src/components/AgeSelector.tsx
+++ b/frontend/src/components/AgeSelector.tsx
@@ -1,0 +1,106 @@
+import { useState, useEffect } from 'react';
+
+interface AgeSelectorProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: (age: string) => void;
+}
+
+/**
+ * AgeSelector - Modal for selecting specific child age
+ * Opens when user clicks "その他" button
+ */
+export default function AgeSelector({ isOpen, onClose, onConfirm }: AgeSelectorProps) {
+  const [selectedAge, setSelectedAge] = useState<string>('0');
+
+  // Close on ESC key
+  useEffect(() => {
+    const handleEsc = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      window.addEventListener('keydown', handleEsc);
+    }
+
+    return () => {
+      window.removeEventListener('keydown', handleEsc);
+    };
+  }, [isOpen, onClose]);
+
+  // Prevent body scroll when modal is open
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
+
+  const handleConfirm = () => {
+    // Send age in format "X歳"
+    onConfirm(`${selectedAge}歳`);
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  // Generate age options (0-12)
+  const ageOptions = Array.from({ length: 13 }, (_, i) => i);
+
+  return (
+    <>
+      {/* Background Overlay */}
+      <div
+        className="fixed inset-0 bg-black bg-opacity-50 z-50 transition-opacity"
+        onClick={onClose}
+      />
+
+      {/* Modal */}
+      <div className="fixed z-50 top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-white rounded-lg shadow-2xl p-6 w-80">
+        <h3 className="text-lg font-bold text-gray-900 mb-4">お子様の年齢を選択</h3>
+
+        {/* Dropdown */}
+        <div className="mb-6">
+          <label htmlFor="age-select" className="block text-sm font-medium text-gray-700 mb-2">
+            年齢
+          </label>
+          <select
+            id="age-select"
+            value={selectedAge}
+            onChange={(e) => setSelectedAge(e.target.value)}
+            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-base"
+          >
+            {ageOptions.map((age) => (
+              <option key={age} value={age}>
+                {age}歳
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Buttons */}
+        <div className="flex gap-3">
+          <button
+            onClick={onClose}
+            className="flex-1 px-4 py-3 bg-white border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors font-medium"
+          >
+            キャンセル
+          </button>
+          <button
+            onClick={handleConfirm}
+            className="flex-1 px-4 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium"
+          >
+            決定
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/ChatContainer.tsx
+++ b/frontend/src/components/ChatContainer.tsx
@@ -6,6 +6,7 @@ import MapDisplay from './MapDisplay';
 import PlanSummary from './PlanSummary';
 import EnrichedPlaceCard from './EnrichedPlaceCard';
 import PlaceDrawer from './PlaceDrawer';
+import AgeSelector from './AgeSelector';
 import type { TravelPlan } from '../types/plan';
 import { mockPlan } from '../data/mockPlan';
 import { useSession } from '../hooks/useSession';
@@ -47,6 +48,9 @@ export default function ChatContainer() {
   // Drawer state
   const [selectedPlaceIndex, setSelectedPlaceIndex] = useState<number | null>(null);
 
+  // Age selector state
+  const [showAgeSelector, setShowAgeSelector] = useState(false);
+
   // Auto-scroll to bottom when new messages arrive
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -73,6 +77,18 @@ export default function ChatContainer() {
   // Handle quick reply click
   const handleQuickReply = (reply: string) => {
     sendMessage(reply);
+  };
+
+  // Handle special reply (opens age selector)
+  const handleSpecialReply = (reply: string) => {
+    if (reply === 'その他') {
+      setShowAgeSelector(true);
+    }
+  };
+
+  // Handle age confirmation from selector
+  const handleAgeConfirm = (age: string) => {
+    sendMessage(age);
   };
 
   // Handle use current location
@@ -297,7 +313,11 @@ export default function ChatContainer() {
 
               {/* Quick Replies */}
               {!isLoading && !currentPlan && quickReplies.length > 0 && (
-                <QuickReplies replies={quickReplies} onReplyClick={handleQuickReply} />
+                <QuickReplies
+                  replies={quickReplies}
+                  onReplyClick={handleQuickReply}
+                  onSpecialReply={handleSpecialReply}
+                />
               )}
 
               {/* Scroll anchor */}
@@ -331,6 +351,13 @@ export default function ChatContainer() {
           hasNext={selectedPlaceIndex < enrichedPlaces.length - 1}
         />
       )}
+
+      {/* Age Selector Modal */}
+      <AgeSelector
+        isOpen={showAgeSelector}
+        onClose={() => setShowAgeSelector(false)}
+        onConfirm={handleAgeConfirm}
+      />
     </div>
   );
 }

--- a/frontend/src/components/QuickReplies.tsx
+++ b/frontend/src/components/QuickReplies.tsx
@@ -6,19 +6,29 @@
 interface QuickRepliesProps {
   replies: string[];
   onReplyClick: (reply: string) => void;
+  onSpecialReply?: (reply: string) => void; // Optional handler for special replies like "その他"
 }
 
-export default function QuickReplies({ replies, onReplyClick }: QuickRepliesProps) {
+export default function QuickReplies({ replies, onReplyClick, onSpecialReply }: QuickRepliesProps) {
   if (!replies || replies.length === 0) {
     return null;
   }
+
+  const handleClick = (reply: string) => {
+    // Check if this is a special reply that needs custom handling
+    if (reply === 'その他' && onSpecialReply) {
+      onSpecialReply(reply);
+    } else {
+      onReplyClick(reply);
+    }
+  };
 
   return (
     <div className="flex flex-wrap gap-2 mb-4">
       {replies.map((reply, index) => (
         <button
           key={index}
-          onClick={() => onReplyClick(reply)}
+          onClick={() => handleClick(reply)}
           className="px-4 py-2 bg-white border-2 border-blue-500 text-blue-700 rounded-full hover:bg-blue-50 transition-colors font-medium text-sm"
         >
           {reply}


### PR DESCRIPTION
## Summary

Implements Issue #38 by adding a hybrid UI for age selection with quick reply buttons for age groups plus a dropdown modal for specific age selection.

## Changes

### Backend
- **Add age group quick replies** (`backend/app/routes/chat.py`)
  - Quick replies: `["0-2歳", "3-5歳", "6-8歳", "9-12歳", "その他"]`
  - Replaces the previous text-only input
  
- **Update age extraction regex** (`backend/app/routes/chat.py`)
  - Pattern: `r'(\d+(?:-\d+)?)[歳才]'`
  - Handles both single ages ("3歳") and age ranges ("0-2歳")

### Frontend
- **Create AgeSelector component** (`frontend/src/components/AgeSelector.tsx`)
  - Modal with dropdown for ages 0-12
  - Opens when user clicks "その他" button
  - ESC key and overlay click to close
  - Prevents body scroll when open
  - Sends selected age in format "X歳"

- **Enhance QuickReplies component** (`frontend/src/components/QuickReplies.tsx`)
  - Added optional `onSpecialReply` prop
  - Detects "その他" button for custom handling
  - Maintains backward compatibility

- **Integrate into ChatContainer** (`frontend/src/components/ChatContainer.tsx`)
  - Added AgeSelector modal
  - Added state and handlers for age selection
  - Connected QuickReplies with special reply handler

## User Flow

1. User reaches age question during preferences gathering
2. Backend sends quick replies with 4 age groups + "その他"
3. Two options:
   - **Click age group button** → Sends "0-2歳" directly → Backend extracts "0-2"
   - **Click "その他" button** → Opens modal → Select specific age from dropdown → Click "決定" → Sends "3歳" → Backend extracts "3"

## Screenshots

_(User can test at http://localhost:5173/)_

## Testing

- ✅ Frontend compiles without TypeScript errors
- ✅ Quick reply buttons render correctly
- ✅ Age group selection sends correct format
- ✅ "その他" button opens modal
- ✅ Modal dropdown has ages 0-12
- ✅ Backend regex handles both formats

## Related Issues

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)