### PR TITLE
Implement show more spots feature with Quick Reply (Issue #40)

### DIFF
--- a/backend/app/models/conversation.py
+++ b/backend/app/models/conversation.py
@@ -44,6 +44,8 @@ class UserPreferences(BaseModel):
     child_age: str | None = None
     transportation: str | None = None  # "car", "public", "walking"
     special_requirements: list[str] = Field(default_factory=list)
+    shown_place_ids: list[str] = Field(default_factory=list)  # Track shown place IDs to avoid duplicates
+    spots_request_count: int = 0  # Number of additional spot requests (0, 1, 2)
 
 
 class ChatMessage(BaseModel):

--- a/backend/app/services/prompts.py
+++ b/backend/app/services/prompts.py
@@ -113,6 +113,7 @@ class PromptTemplates:
         transportation: str | None = None,
         latitude: float | None = None,
         longitude: float | None = None,
+        exclude_place_ids: list[str] | None = None,
     ) -> str:
         """
         Create optimized prompt for travel plan generation with Maps grounding.
@@ -195,6 +196,20 @@ class PromptTemplates:
 - 実際の施設名、住所、アクセス情報を正確に記載
 - 移動時間は現実的な時間を
 - 簡潔かつ具体的に（各施設200文字程度）
+{_generate_exclusion_section(exclude_place_ids)}
+"""
+
+
+def _generate_exclusion_section(exclude_place_ids: list[str] | None) -> str:
+    """Generate exclusion section for already-shown places."""
+    if not exclude_place_ids or len(exclude_place_ids) == 0:
+        return ""
+
+    return f"""
+
+## 除外する施設
+以下のGoogle Place IDは既に提案済みです。**必ずこれらの施設を除外し、別の施設を提案してください**:
+{chr(10).join(f"- {place_id}" for place_id in exclude_place_ids)}
 """
 
     @staticmethod

--- a/frontend/src/components/ChatContainer.tsx
+++ b/frontend/src/components/ChatContainer.tsx
@@ -312,7 +312,7 @@ export default function ChatContainer() {
               )}
 
               {/* Quick Replies */}
-              {!isLoading && !currentPlan && quickReplies.length > 0 && (
+              {!isLoading && quickReplies.length > 0 && (
                 <QuickReplies
                   replies={quickReplies}
                   onReplyClick={handleQuickReply}

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -69,8 +69,9 @@ export function useChat(sessionId: string | null) {
         }
 
         // Update enriched places if provided
+        // Append new places to existing ones (for "show more" functionality)
         if (response.enriched_places && response.enriched_places.length > 0) {
-          setEnrichedPlaces(response.enriched_places);
+          setEnrichedPlaces((prev) => [...prev, ...(response.enriched_places || [])]);
         }
 
         return response;


### PR DESCRIPTION
## Summary

Implements Issue #40 by adding a \"他の候補を見る\" Quick Reply button that allows users to request additional spot options. Users can request up to 2 additional sets (3→6→9 spots total), with duplicate prevention.

## Changes

### Backend

**1. User Preferences Tracking** (`backend/app/models/conversation.py`)
- Added `shown_place_ids: list[str]` - Tracks displayed place IDs to avoid duplicates
- Added `spots_request_count: int` - Counts additional requests (0, 1, 2)

**2. Prompt Enhancement** (`backend/app/services/prompts.py`)
- Added `exclude_place_ids` parameter to `generate_travel_plan()`
- New helper function `_generate_exclusion_section()` - Generates exclusion prompt for already-shown places
- Exclusion format: Passes place IDs to LLM with instruction to avoid

**3. Plan Generation** (`backend/app/routes/chat.py`)
- Store initial place IDs after first plan generation
- Add Quick Reply: `["他の候補を見る"]` when `spots_request_count < 2`

**4. Additional Spots Logic** (`backend/app/routes/chat.py` - PRESENTING_PLAN state)
- Detect \"他の候補\" trigger
- Check request limit (max 2 additional requests)
- Generate prompt with `exclude_place_ids` parameter
- Use `temperature=0.85` for diversity
- Append new place IDs to `shown_place_ids`
- Increment `spots_request_count`
- Return Quick Reply button until limit reached

### Frontend

**5. Append Mode** (`frontend/src/hooks/useChat.ts`)
- Changed enriched places update from **replace** to **append**
- Old: `setEnrichedPlaces(response.enriched_places)`
- New: `setEnrichedPlaces((prev) => [...prev, ...(response.enriched_places || [])])`

**6. Quick Reply Display** (`frontend/src/components/ChatContainer.tsx`)
- Removed `!currentPlan` condition
- Old: `{!isLoading && !currentPlan && quickReplies.length > 0 && ...}`
- New: `{!isLoading && quickReplies.length > 0 && ...}`
- Allows Quick Reply to show while plan is displayed

## User Flow

1. **Initial Plan**
   - Shows 3 spots
   - Quick Reply: [\"他の候補を見る\"]
   - `shown_place_ids`: [id1, id2, id3]
   - `spots_request_count`: 0

2. **First Additional Request**
   - User clicks \"他の候補を見る\"
   - Generates 3 more spots (excluding id1-3)
   - Shows 6 spots total
   - Quick Reply: [\"他の候補を見る\"]
   - `shown_place_ids`: [id1-id6]
   - `spots_request_count`: 1

3. **Second Additional Request**
   - User clicks \"他の候補を見る\" again
   - Generates 3 more spots (excluding id1-6)
   - Shows 9 spots total
   - Quick Reply: None (limit reached)
   - `shown_place_ids`: [id1-id9]
   - `spots_request_count`: 2

4. **Limit Reached**
   - No Quick Reply button
   - Further requests show: \"申し訳ございませんが、これ以上の候補はご用意できません。\"

## Features

- ✅ Append spots instead of replacing
- ✅ Duplicate prevention via place_id tracking
- ✅ Maximum 9 spots (3 initial + 6 additional)
- ✅ Quick Reply button auto-hides at limit
- ✅ Higher temperature (0.85) for diversity
- ✅ Exclusion prompt passed to LLM

## Testing

Manual testing steps:
1. Complete preferences gathering
2. View initial 3 spots
3. Click \"他の候補を見る\" → see 6 spots
4. Click \"他の候補を見る\" again → see 9 spots
5. Verify button disappears
6. Verify no duplicate spots appear

## Files Changed

- `backend/app/models/conversation.py` - Added tracking fields
- `backend/app/services/prompts.py` - Added exclusion logic
- `backend/app/routes/chat.py` - Implemented additional spots generation
- `frontend/src/hooks/useChat.ts` - Changed to append mode
- `frontend/src/components/ChatContainer.tsx` - Updated Quick Reply conditions

## Related Issues

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)