### PR TITLE
Add map markers with auto-zoom and click-to-open-drawer functionality

### DIFF
--- a/frontend/src/components/ChatContainer.tsx
+++ b/frontend/src/components/ChatContainer.tsx
@@ -18,6 +18,7 @@ interface Location {
   lat: number;
   lng: number;
   name?: string;
+  index?: number; // Marker number for display
 }
 
 /**
@@ -79,6 +80,24 @@ export default function ChatContainer() {
       );
     }
   }, [sessionId, messages.length, addGreeting]);
+
+  // Update map markers when enriched places change
+  useEffect(() => {
+    if (enrichedPlaces && enrichedPlaces.length > 0) {
+      const markers = enrichedPlaces
+        .filter((place) => place.location) // Only places with valid location
+        .map((place, index) => ({
+          lat: place.location!.lat,
+          lng: place.location!.lng,
+          name: place.name,
+          index: index + 1, // Marker number (1, 2, 3...)
+        }));
+
+      setMapMarkers(markers);
+    } else {
+      setMapMarkers([]); // Clear markers when list is cleared
+    }
+  }, [enrichedPlaces]);
 
   // Combine errors from session and chat
   const error = sessionError || chatError;
@@ -413,6 +432,7 @@ export default function ChatContainer() {
             markers={mapMarkers}
             routes={mapRoutes}
             directionsResult={directionsResult}
+            onMarkerClick={(index) => setSelectedPlaceIndex(index)}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Display numbered markers on map when enrichedPlaces list is shown
- Auto-zoom map to fit all markers with 80px padding for better UX
- Enable clicking map markers to open corresponding place drawer

## Changes
- Updated `Location` interface to include optional `index` property for marker numbering
- Added useEffect in `ChatContainer.tsx` to convert enrichedPlaces to map markers
- Modified `MapDisplay.tsx` to create numbered markers with custom styling
- Implemented fitBounds with padding to show all markers in viewport
- Added marker click handler callback to open drawer when marker is clicked

## How it works
1. When enrichedPlaces are received from backend, they're automatically converted to map markers
2. Each marker shows a number (1, 2, 3...) matching the order in the list
3. Map automatically zooms to show all markers with padding
4. Clicking a marker opens the corresponding place drawer

## Test plan
- [x] Verify markers appear when enriched places are loaded
- [x] Confirm markers are numbered correctly (1, 2, 3...)
- [x] Check that map auto-zooms to fit all markers
- [x] Test clicking markers opens the correct place drawer
- [x] Verify frontend compiles without errors

Fixes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)