### PR TITLE
Remove confusing black background overlay from PlaceDrawer

### DIFF
--- a/frontend/src/components/PlaceDrawer.tsx
+++ b/frontend/src/components/PlaceDrawer.tsx
@@ -134,17 +134,7 @@ export default function PlaceDrawer({
   };
 
   return (
-    <>
-      {/* Background Overlay */}
-      <div
-        className={`fixed inset-0 bg-black z-40 transition-opacity duration-300 ${
-          isMounted ? 'bg-opacity-50' : 'bg-opacity-0'
-        }`}
-        onClick={onClose}
-      />
-
-      {/* Drawer */}
-      <div
+    <div
         className={`
           fixed z-50 bg-white shadow-2xl overflow-hidden
           md:top-0 md:right-0 md:h-full md:w-2/5
@@ -421,6 +411,5 @@ export default function PlaceDrawer({
           </div>
         )}
       </div>
-    </>
   );
 }


### PR DESCRIPTION
## Summary
Removes the black background overlay from PlaceDrawer that was confusing users.

## Changes
- Removed background overlay div that was blocking map and chat interaction
- Changed wrapper from fragment (`<>`) to direct `<div>` return
- Drawer now slides in/out without darkening the rest of the UI

## Related Issue
Part of #44 - Drawer animation improvements

## Test Plan
- [x] Open PlaceDrawer by clicking on a place card or map marker
- [x] Verify drawer slides in smoothly from right (desktop) or bottom (mobile)
- [x] Verify no black overlay appears behind the drawer
- [x] Verify map and chat remain visible and interactive
- [x] Close drawer and verify smooth slide-out animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)